### PR TITLE
Refatoração de funcões de leitura e escrita de JSON

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -241,9 +241,14 @@ func (dbc *DBController) save() error {
 		return fmt.Errorf("error create table metadata")
 	}
 
-	err = dbc.saveMetadata(filepath.Join(tbl.GetPath(), tbl.GetName()+".json"), metadados)
+	fp, err := services.FSbuildJSONFile(tbl.GetPath(), tbl.GetName(), ".json")
 	if err != nil {
-		return fmt.Errorf("error save metadata to controller")
+		return fmt.Errorf("error create metadata file")
+	}
+
+	err = dbc.writeMetadata(fp, metadados)
+	if err != nil {
+		return fmt.Errorf("error save metadata")
 	}
 
 	return nil

--- a/controller/controller_utils.go
+++ b/controller/controller_utils.go
@@ -3,27 +3,29 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/rafakimanja/LittleLiteDB/types"
 	"os"
+
+	"github.com/rafakimanja/LittleLiteDB/services"
+	"github.com/rafakimanja/LittleLiteDB/types"
 )
 
-func (dbc *DBController) saveMetadata(filename string, metadata Metadata) error {	
-	_, err := os.ReadFile(filename)
-	if err != nil {
-		return err
-	}
+func (dbc *DBController) writeMetadata(pathFile string, metadata Metadata) error {	
+	if services.FSvalidFile(pathFile) {
 
-	data, err := json.MarshalIndent(metadata, "", "  ")
-	if err != nil {
-		return err
-	}
+		_, err := os.ReadFile(pathFile)
+		if err != nil {
+			return err
+		}
 
-	err = os.WriteFile(filename, data, 0644)
-	if err != nil {
-		return err
-	}
+		data, err := json.MarshalIndent(metadata, "", "  ")
+		if err != nil {
+			return err
+		}
 
-	return nil
+		return os.WriteFile(pathFile, data, 0644)
+	}
+	
+	return fmt.Errorf("filepath invalid")
 }
 
 func (dbc *DBController) readMetadata(filename string) (*Metadata, error){

--- a/examples/car_example.go
+++ b/examples/car_example.go
@@ -54,5 +54,5 @@ func DeleteCar(){
 }
 
 func main(){
-	MigrationCar()
+	SelectCar()
 }

--- a/services/fsutil_service.go
+++ b/services/fsutil_service.go
@@ -21,20 +21,29 @@ func FSvalidPath(path string) bool {
 	return !os.IsNotExist(err)
 }
 
-func FSbuildJSONFile(dirPath string, name string, suffix string) error {
+func FSvalidFile(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}
+
+func FSbuildJSONFile(dirPath string, name string, suffix string) (string, error) {
 	lowerName := strings.ToLower(name)
 	fullPath := filepath.Join(dirPath, lowerName+suffix)
 	if FSvalidPath(dirPath) {	
 		file, err := os.Create(fullPath)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		defer file.Close()
 
 		_, err = file.WriteString("[]")
-		return err
+		if err != nil {
+			return "", err
+		} else {
+			return fullPath, nil
+		}
 	} else {
-		return fmt.Errorf("dirPath invalid")
+		return "", fmt.Errorf("dirPath invalid")
 	}
 }

--- a/table/table.go
+++ b/table/table.go
@@ -76,19 +76,24 @@ func (t *Table) create(table any) error {
 		return fmt.Errorf("table path does not exist")
 	}
 
-	err := t.createFile(t.name)
+	_, err := services.FSbuildJSONFile(t.path, t.name, ".json")
 	if err != nil {
 		return err
 	}
 
-	if strings.ToLower(t.name) != "ormmeta" {
+	if strings.ToLower(t.name) != "metadata" {
 		tableModel, err := types.Init(table)
 		if err != nil {
 			return err
 		}
 
+		fp, err := services.FSbuildJSONFile(t.path, t.name, ".config.json")
+		if err != nil {
+			return err
+		}
+
 		configs := t.extractConfig(tableModel.GetContent())
-		err = t.createConfigFile(configs, t.name)
+		err = t.writeConfigFile(fp, configs)
 		if err != nil {
 			return err
 		}

--- a/table/table_utils.go
+++ b/table/table_utils.go
@@ -2,41 +2,27 @@ package table
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
+
+	"github.com/rafakimanja/LittleLiteDB/services"
 )
 
-func (t *Table) createFile(name string) error {
-	lowerName := strings.ToLower(name)
-	fullPath := filepath.Join(t.path, lowerName)
-	file, err := os.Create(fullPath+".json")
-	if err != nil {
-		return err
+func (t *Table) writeConfigFile(pathFile string, dados []TableConfig) error {
+	if services.FSvalidFile(pathFile){
+
+		_, err := os.ReadFile(pathFile)
+		if err != nil {
+			return err
+		}
+
+		bytes, err := json.MarshalIndent(dados, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(pathFile, bytes, 0644)
 	}
 
-	defer file.Close()
-
-	_, err = file.WriteString("[]")
-	return err
-}
-
-func (t *Table) createConfigFile(dados []TableConfig, name string) error {
-	lowerName := strings.ToLower(name)
-	fullPath := filepath.Join(t.path, lowerName)
-	file, err := os.Create(fullPath+".config.json")
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
-	encoder := json.NewEncoder(file)
-	encoder.SetIndent("", "  ")
-
-	err = encoder.Encode(dados)
-	if err != nil {
-		return err
-	}
-	return nil
+	return fmt.Errorf("filepath invalid")
 }


### PR DESCRIPTION
Resolvendo o problema envolvendo a tabela Metadata. 

Bug > tabela metadata era criada com arquivos em maiúsculo e arquivo também com arquivo metadata.config.json

Resolução > refatoração de códigos de criação de arquivos, criando uma nova função no módulo de services e FS, unificando em um unico lugar